### PR TITLE
Add --additional-libs option

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -16,6 +16,7 @@ module Brakeman
   #
   #Options:
   #
+  #  * :additional_libs - array of additional lib directories to process
   #  * :app_path - path to root of Rails app (required)
   #  * :assume_all_routes - assume all methods are routes (default: true)
   #  * :check_arguments - check arguments of methods (default: true)

--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -15,6 +15,7 @@ module Brakeman
       if options[:only_files]
         init_options[:only_files] = Regexp.new("(?:" << options[:only_files].map { |f| Regexp.escape f }.join("|") << ")")
       end
+      init_options[:additional_libs] = options[:additional_libs]
       new(root, init_options)
     end
 
@@ -22,6 +23,7 @@ module Brakeman
       @root = root
       @skip_files = init_options[:skip_files]
       @only_files = init_options[:only_files]
+      @additional_libs = init_options[:additional_libs] || []
     end
 
     def expand_path(path)
@@ -72,13 +74,14 @@ module Brakeman
 
     def lib_paths
       @lib_files ||= find_paths("lib").reject { |path| path.include? "/generators/" } +
-                     find_paths("app/helpers") +
-                     find_paths("app/api") +
-                     find_paths("app/mailers") +
-                     find_paths("app/view_models")
+                     find_additional_lib_paths
     end
 
   private
+
+    def find_additional_lib_paths
+      @additional_libs.collect{ |path| find_paths path }.flatten
+    end
 
     def find_paths(directory, extensions = "*.rb")
       pattern = @root + "/{engines/*/,}#{directory}/**/#{extensions}"

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -111,6 +111,11 @@ module Brakeman::Options
           options[:skip_libs] = true
         end
 
+        opts.on "--additional-libs path1,path2,etc", Array, "Process these additional lib directories" do |paths|
+          options[:additional_libs] ||= Set.new
+          options[:additional_libs].merge paths
+        end
+
         opts.on "-t", "--test Check1,Check2,etc", Array, "Only run the specified checks" do |checks|
           checks.each_with_index do |s, index|
             if s[0,5] != "Check"
@@ -158,7 +163,7 @@ module Brakeman::Options
         end
 
         opts.on "-I", "--interactive-ignore", "Interactively ignore warnings" do
-          options[:interactive_ignore] = true 
+          options[:interactive_ignore] = true
         end
 
         opts.on "-l", "--[no-]combine-locations", "Combine warning locations (Default)" do |combine|

--- a/lib/brakeman/version.rb
+++ b/lib/brakeman/version.rb
@@ -1,3 +1,3 @@
 module Brakeman
-  Version = "2.4.3github4"
+  Version = "2.4.3github5"
 end


### PR DESCRIPTION
Add `--additional-libs` command line and `:additional_libs` key to set additional lib directories to scan.

:tada: `bin/brakeman app/path --additional-libs app/helpers,app/api,app/mailers,app/view_models`

/cc https://github.com/github/brakeman/pull/6 @mastahyeti 
